### PR TITLE
Latest MacOS clang++ fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ def prepare_env_for_osx():
         '20': '11.5',
     }
     os.environ['CXX'] = 'clang++'
+    os.environ['CXXFLAGS'] = '-std=c++17' # Default clang++ cause compiler error
     os.environ['CC'] = 'clang'
     darwin_major = os.uname()[2].split('.')[0]
     if darwin_major in darwin_major_to_osx_map:


### PR DESCRIPTION
Fixes `/usr/include/c++/v1/__exception/exception_ptr.h:105:20: error: expected expression auto __cleanup = [](void* __p) { ... };` error